### PR TITLE
Fix typo in --node_pattern_file flag.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ EXPOSE 80
 CMD /sync.py \
     --datastore_namespace=$NAMESPACE \
     --spreadsheet=$SPREADSHEET \
-    --node-pattern-file=$NODE_PATTERN_FILE
+    --node_pattern_file=$NODE_PATTERN_FILE


### PR DESCRIPTION
Addresses https://github.com/m-lab/scraper-sync/issues/18

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/scraper-sync/19)
<!-- Reviewable:end -->
