### PR TITLE
Deploys to prod on tag creation. Deploys to staging on pushes to master.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ deploy:
   on:
     repo: m-lab/scraper-sync
     all_branches: true
-    condition: $TRAVIS_BRANCH == staging && $TRAVIS_EVENT_TYPE == push
+    condition: $TRAVIS_BRANCH == master && $TRAVIS_EVENT_TYPE == push
 
 ####################################
 ## Production
@@ -40,8 +40,7 @@ deploy:
   script: ./deploy.sh production travis
   on:
     repo: m-lab/scraper-sync
-    all_branches: true
-    condition: $TRAVIS_BRANCH == master && $TRAVIS_EVENT_TYPE == push
+    tags: true
 
 before_install:
 - travis/decrypt.sh "$encrypted_c6050636c18f_key" "$encrypted_c6050636c18f_iv"


### PR DESCRIPTION
We've settled on this after some time, and it seems to work a little more cleanly than the "make a staging->master pull request" method we tried in the past.  I'll push this to staging as a last reminder of the old way, and then make a PR to bring staging and master together.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/scraper-sync/35)
<!-- Reviewable:end -->
