### PR TITLE
Change node label to scraper-sync-node.

### DIFF
--- a/sync.yml
+++ b/sync.yml
@@ -43,7 +43,7 @@ spec:
       # permissions to write to the spreadsheet.
       # TODO(https://github.com/m-lab/scraper-sync/issues/40)
       nodeSelector:
-        scraper-node: 'true'
+        scraper-sync-node: 'true'
       containers:
         - name: scraper-sync
           image: '{{IMAGE_URL}}'


### PR DESCRIPTION
To prevent scraper pods from being placed on sync nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/scraper-sync/44)
<!-- Reviewable:end -->
