### PR TITLE
No longer require so many resources for scraper-sync.

### DIFF
--- a/sync.yml
+++ b/sync.yml
@@ -54,11 +54,11 @@ spec:
               value: '{{SPREADSHEET_ID}}'
           resources:
             requests:
-              memory: "5Gi"
-              cpu: "4"
+              memory: "1Gi"
+              cpu: "1"
             limits:
-              memory: "7Gi"
-              cpu: "7"
+              memory: "1Gi"
+              cpu: "1"
           ports:
             - containerPort: 80
             - containerPort: 9090


### PR DESCRIPTION
The bottleneck has been found and fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/scraper-sync/48)
<!-- Reviewable:end -->
